### PR TITLE
In and Reader nodes conflict

### DIFF
--- a/library/automationhatlink.py
+++ b/library/automationhatlink.py
@@ -110,8 +110,8 @@ def fatal(message):
 
 def handle_input(buffered_input, forceEmit=False):
     global input_last_value
-    emit_message = False
     for input_channel in channels:
+        emit_message = False
         if input_last_value[channels[input_channel]] is None:
             emit_message = False  # Supress emit on 1st read/startup
         elif input_last_value[channels[input_channel]] != buffered_input[input_channel]:
@@ -122,8 +122,8 @@ def handle_input(buffered_input, forceEmit=False):
         input_last_value[channels[input_channel]] = buffered_input[input_channel]
         if emit_message:
             emit(
-                "input.{}:{}".format(
-                    channels[input_channel], buffered_input[input_channel]
+                "input.{}:{}:{}".format(
+                    channels[input_channel], buffered_input[input_channel], forceEmit
                 )
             )
 
@@ -132,8 +132,8 @@ def handle_analog(analog, forceEmit=False):
     global last_analog_value
     global threshold
 
-    emit_message = False
     for analog_channel in analog_inputs:
+        emit_message = False
         channel = analog_inputs[analog_channel]
         value = analog[analog_channel]
         trigger_threshold = threshold
@@ -148,7 +148,7 @@ def handle_analog(analog, forceEmit=False):
 
         last_analog_value[channel] = value
         if emit_message:
-            emit("analog.{}:{}".format(channel, value))
+            emit("analog.{}:{}:{}".format(channel, value, forceEmit))
 
 
 def handle_command(command):

--- a/nodes/rpi-automationhat.js
+++ b/nodes/rpi-automationhat.js
@@ -79,22 +79,28 @@ module.exports = function(RED) {
                 }
 
                 users.forEach(function(node){
-                    if ( data.substring(0,6) == "analog" && (node.send_analog || node.send_reader_analog) ){
+                    if ( data.substring(0,6) == "analog" ){
                         var channel = data.substring(7,8);
                         var msg = data.split(":")[1];
-                        if(msgObj && msgObj.req && msgObj.res){
-                            node.send({topic:"automationhat/analog." + channel, payload:Number(msg), req : msgObj.req, res : msgObj.res});
-                        } else {
-                            node.send({topic:"automationhat/analog." + channel, payload:Number(msg)});
+                        var isForReader = data.split(":")[2] == "True";
+                        if((!isForReader && node.send_analog) || (isForReader && node.send_reader_analog)){
+                            if(msgObj && msgObj.req && msgObj.res){
+                                node.send({topic:"automationhat/analog." + channel, payload:Number(msg), req : msgObj.req, res : msgObj.res});
+                            } else {
+                                node.send({topic:"automationhat/analog." + channel, payload:Number(msg)});
+                            }
                         }
                     }
-                    else if ( data.substring(0,5) == "input" && (node.send_input || node.send_reader_input) ){
+                    else if ( data.substring(0,5) == "input" ){
                         var channel = data.substring(6,7);
                         var msg = data.split(":")[1];
-                        if(msgObj && msgObj.req && msgObj.req){
-                            node.send({topic:"automationhat/input." + channel, payload:Number(msg), req : msgObj.req, res: msgObj.res});
-                        } else {
-                            node.send({topic:"automationhat/input." + channel, payload:Number(msg)});
+                        var isForReader = data.split(":")[2] == "True";
+                        if((!isForReader && node.send_input) || (isForReader && node.send_reader_input)){
+                            if(msgObj && msgObj.req && msgObj.req){
+                                node.send({topic:"automationhat/input." + channel, payload:Number(msg), req : msgObj.req, res: msgObj.res});
+                            } else {
+                                node.send({topic:"automationhat/input." + channel, payload:Number(msg)});
+                            }
                         }
                     }
                 });


### PR DESCRIPTION
I was testing this with both an "In" and a "Reader" node active in the same flow. I noticed that the "Input Events" and "Analog Events" check boxes under both the In and Reader node's settings were not working properly, and also that events were being duplicated across both nodes. More specifically:

-If either the In or the Reader node's "Input Events" check box was checked, input events were generated for both nodes. If both were unchecked then nothing was generated

-If an input on the board was toggled or analog voltage changed, the In node would emit messages as expected, but the Reader node would also emit the same messages without any trigger message on it's input.

-If a trigger message was sent to the Reader node, it would emit the status of the inputs as expected, but the In node would also emit the same messages without the inputs actually having changed.

My suggested fixes make them work as I expected (which may be different from other people's expectations) detailed below:

-The In node should only emit messages when either a digital input changes status, or an analog input changes by the threshold amounts.

-The Reader node should only emit messages if a trigger message is sent to it on it's input side.

-The "Input Events" and "Analog Events" check boxes should enable or disable the corresponding event types for their containing nodes only.